### PR TITLE
fix: update poster URLs to baker-scripts org, add refresh configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Kometa (formerly Plex Meta Manager) configuration files for automated Plex libra
 - `tv.yml` — TV show collections
 - `tv-meta.yml` — TV show metadata configs
 - `tv-networks.yml` — TV network collections
+- `aired-refresh.yml` — Hidden collections for recently-aired metadata refresh
+- `unmatched-refresh.yml` — Hidden collection to retry matching unmatched items
 - `video-overlays.yml` — Video overlay definitions
 - `Overlays/` — Custom overlay images
 - `Posters/` — Custom collection posters

--- a/aired-refresh.yml
+++ b/aired-refresh.yml
@@ -1,0 +1,54 @@
+##############################################################################
+# Aired Recently - Metadata Refresh
+#
+# Hidden collections that refresh metadata for shows with recently aired
+# episodes. More frequent refresh for very recent episodes.
+##############################################################################
+
+collections:
+  # Frequent refresh for shows aired in last 3 days
+  Aired Last 3 Days (Refresh):
+    visible_home: false
+    visible_library: false
+    visible_shared: false
+
+    # Run 5x daily: 6am, 12pm, 3pm, 6pm, 10pm
+    schedule:
+      - hourly(6)
+      - hourly(12)
+      - hourly(15)
+      - hourly(18)
+      - hourly(22)
+
+    plex_search:
+      all:
+        episode_air_date: 3
+
+    item_refresh: true
+    item_refresh_delay: 2
+    sync_mode: sync
+    collection_order: alpha
+
+    summary: "Internal - refresh metadata for shows with episodes aired in last 3 days."
+
+  # Less frequent refresh for shows aired in last week
+  Aired Last Week (Refresh):
+    visible_home: false
+    visible_library: false
+    visible_shared: false
+
+    # Run 2x daily: 6am, 6pm
+    schedule:
+      - hourly(6)
+      - hourly(18)
+
+    plex_search:
+      all:
+        episode_air_date: 7
+
+    item_refresh: true
+    item_refresh_delay: 2
+    sync_mode: sync
+    collection_order: alpha
+
+    summary: "Internal - refresh metadata for shows with episodes aired in last 7 days."

--- a/movies-best.yml
+++ b/movies-best.yml
@@ -60,7 +60,7 @@ collections:
     template: { name: Chart, num: 5 }
     imdb_list: https://www.imdb.com/search/title/?title_type=feature,documentary&groups=oscar_winner
     summary: Oscar Winning Movies
-    url_poster: https://github.com/bakerboy448/plex-meta-manger/raw/main/Posters/oscars.png
+    url_poster: https://github.com/baker-scripts/pmm-config/raw/main/Posters/oscars.png
     url_background: https://i.imgur.com/0Kao9gY.jpeg
   Best of 2022:
     template: { name: Best of, year: 2022, num: 1 }

--- a/networks.yml
+++ b/networks.yml
@@ -64,7 +64,7 @@ metadata:
   ALLBLK:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/ALLBLK/poster.jpg
   AMC:
-    url_poster: https://github.com/bakerboy448/plex-meta-manger/raw/main/Posters/logos/png/AMC.png
+    url_poster: https://github.com/baker-scripts/pmm-config/raw/main/Posters/logos/png/AMC.png
   AMC+:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/AMC%2B/poster.jpg
   AMI-tl:
@@ -118,7 +118,7 @@ metadata:
   Action:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/Action/poster.jpg
   Adult Swim:
-    url_poster: https://github.com/bakerboy448/plex-meta-manger/raw/main/Posters/logos/png/AS.png
+    url_poster: https://github.com/baker-scripts/pmm-config/raw/main/Posters/logos/png/AS.png
   Al Jazeera:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/Al%20Jazeera/poster.jpg
   Al Jazeera America:
@@ -138,7 +138,7 @@ metadata:
   Alpha TV:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/Alpha%20TV/poster.jpg
   Amazon:
-    url_poster: https://github.com/bakerboy448/plex-meta-manger/raw/main/Posters/logos/png/AMZN.png
+    url_poster: https://github.com/baker-scripts/pmm-config/raw/main/Posters/logos/png/AMZN.png
   Amrica Televisin:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/Amrica%20Televisin/poster.jpg
   Amrita TV:
@@ -160,7 +160,7 @@ metadata:
   Apple Music:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/Apple%20Music/poster.jpg
   Apple TV+:
-    url_poster: https://github.com/bakerboy448/plex-meta-manger/raw/main/Posters/logos/png/ATVP.png
+    url_poster: https://github.com/baker-scripts/pmm-config/raw/main/Posters/logos/png/ATVP.png
   Arena:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/Arena/poster.jpg
   ArirangTV:
@@ -204,7 +204,7 @@ metadata:
   BBC News:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/BBC%20News/poster.jpg
   BBC One:
-    Url_poster: https://github.com/bakerboy448/plex-meta-manger/raw/main/Posters/logos/png/BBC.png
+    Url_poster: https://github.com/baker-scripts/pmm-config/raw/main/Posters/logos/png/BBC.png
   BBC Red Button:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/BBC%20Red%20Button/poster.jpg
   BBC Scotland:
@@ -286,7 +286,7 @@ metadata:
   Brat:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/Brat/poster.jpg
   Bravo:
-    url_poster: https://github.com/bakerboy448/plex-meta-manger/raw/main/Posters/logos/png/BRAVO.png
+    url_poster: https://github.com/baker-scripts/pmm-config/raw/main/Posters/logos/png/BRAVO.png
   BritBox:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/BritBox/poster.jpg
   BrutX:
@@ -312,7 +312,7 @@ metadata:
   CBC Television:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/CBC%20Television/poster.jpg
   CBS:
-    url_poster: https://github.com/bakerboy448/plex-meta-manger/raw/main/Posters/logos/png/CBS.png
+    url_poster: https://github.com/baker-scripts/pmm-config/raw/main/Posters/logos/png/CBS.png
   CBS All Access:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/CBS%20All%20Access/poster.jpg
   CBS Reality:
@@ -544,7 +544,7 @@ metadata:
   Direct 8:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/Direct%208/poster.jpg
   Discovery:
-    Url_poster: https://github.com/bakerboy448/plex-meta-manger/raw/main/Posters/logos/png/DSCP.png
+    Url_poster: https://github.com/baker-scripts/pmm-config/raw/main/Posters/logos/png/DSCP.png
   Discovery Asia:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/Discovery%20Asia/poster.jpg
   Discovery Channel:
@@ -572,7 +572,7 @@ metadata:
   Disney XD:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/Disney%20XD/poster.jpg
   Disney+:
-    url_poster: https://github.com/bakerboy448/plex-meta-manger/raw/main/Posters/logos/png/DSNP.png
+    url_poster: https://github.com/baker-scripts/pmm-config/raw/main/Posters/logos/png/DSNP.png
   Disney+ Hotstar:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/Disney%2B%20Hotstar/poster.jpg
   Divinity:
@@ -668,7 +668,7 @@ metadata:
   FEM:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/FEM/poster.jpg
   FOX:
-    url_poster: https://github.com/bakerboy448/plex-meta-manger/raw/main/Posters/logos/png/FOX.png
+    url_poster: https://github.com/baker-scripts/pmm-config/raw/main/Posters/logos/png/FOX.png
   FOX Espaa:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/FOX%20Espaa/poster.jpg
   FOXlife:
@@ -676,7 +676,7 @@ metadata:
   FX:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/FX/poster.jpg
   FXX:
-    url_poster: https://github.com/bakerboy448/plex-meta-manger/raw/main/Posters/logos/png/FXX.png
+    url_poster: https://github.com/baker-scripts/pmm-config/raw/main/Posters/logos/png/FXX.png
   Facebook:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/Facebook/poster.jpg
   Facebook Live:
@@ -844,7 +844,7 @@ metadata:
   HBO Latin America:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/HBO%20Latin%20America/poster.jpg
   HBO Max:
-    url_poster: https://github.com/bakerboy448/plex-meta-manger/raw/main/Posters/logos/png/HMAX.png
+    url_poster: https://github.com/baker-scripts/pmm-config/raw/main/Posters/logos/png/HMAX.png
   HBO Nordic:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/HBO%20Nordic/poster.jpg
   HD1:
@@ -894,7 +894,7 @@ metadata:
   Hub Network:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/Hub%20Network/poster.jpg
   Hulu:
-    url_poster: https://github.com/bakerboy448/plex-meta-manger/raw/main/Posters/logos/png/HULU.png
+    url_poster: https://github.com/baker-scripts/pmm-config/raw/main/Posters/logos/png/HULU.png
   Hum TV:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/Hum%20TV/poster.jpg
   ICI ARTV:
@@ -1228,7 +1228,7 @@ metadata:
   NBA TV:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/NBA%20TV/poster.jpg
   NBC:
-    url_poster: https://github.com/bakerboy448/plex-meta-manger/raw/main/Posters/logos/png/NBC.png
+    url_poster: https://github.com/baker-scripts/pmm-config/raw/main/Posters/logos/png/NBC.png
   NBC Weather Plus:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/NBC%20Weather%20Plus/poster.jpg
   NBCSN:
@@ -1302,7 +1302,7 @@ metadata:
   National Educational Television:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/National%20Educational%20Television/poster.jpg
   National Geographic:
-    url_poster: https://github.com/bakerboy448/plex-meta-manger/raw/main/Posters/logos/png/NGEO.png
+    url_poster: https://github.com/baker-scripts/pmm-config/raw/main/Posters/logos/png/NGEO.png
   National Geographic Brasil:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/National%20Geographic%20Brasil/poster.jpg
   National Geographic Channel:
@@ -1316,7 +1316,7 @@ metadata:
   Net5:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/Net5/poster.jpg
   Netflix:
-    url_poster: https://github.com/bakerboy448/plex-meta-manger/raw/main/Posters/logos/png/NF.png
+    url_poster: https://github.com/baker-scripts/pmm-config/raw/main/Posters/logos/png/NF.png
   Network Ten:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/Network%20Ten/poster.jpg
   Netzun:
@@ -1436,7 +1436,7 @@ metadata:
   Paramount Network:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/Paramount%20Network/poster.jpg
   Paramount+:
-    url_poster: https://github.com/bakerboy448/plex-meta-manger/raw/main/Posters/logos/png/HULPMNTU.png
+    url_poster: https://github.com/baker-scripts/pmm-config/raw/main/Posters/logos/png/HULPMNTU.png
   PassionFlix:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/PassionFlix/poster.jpg
   Pax TV:
@@ -1714,7 +1714,7 @@ metadata:
   Showmax:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/Showmax/poster.jpg
   Showtime:
-    url_poster: https://github.com/bakerboy448/plex-meta-manger/raw/main/Posters/logos/png/SHO.png
+    url_poster: https://github.com/baker-scripts/pmm-config/raw/main/Posters/logos/png/SHO.png
   Shudder:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/Shudder/poster.jpg
   Sistema Brasileiro de Televiso (SBT):
@@ -2072,7 +2072,7 @@ metadata:
   Thai Public Broadcasting Service:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/Thai%20Public%20Broadcasting%20Service/poster.jpg
   The CW:
-    url_poster: https://github.com/bakerboy448/plex-meta-manger/raw/main/Posters/logos/png/CW.png
+    url_poster: https://github.com/baker-scripts/pmm-config/raw/main/Posters/logos/png/CW.png
   The Comedy Channel:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/The%20Comedy%20Channel/poster.jpg
   The Comedy Network:
@@ -2160,7 +2160,7 @@ metadata:
   UPN:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/UPN/poster.jpg
   USA Network:
-    url_poster: https://github.com/bakerboy448/plex-meta-manger/raw/main/Posters/logos/png/USA.png
+    url_poster: https://github.com/baker-scripts/pmm-config/raw/main/Posters/logos/png/USA.png
   UTV:
     url_poster: https://github.com/Drapersniper/Posters/raw/main/networks/UTV/poster.jpg
   Ukraine:

--- a/unmatched-refresh.yml
+++ b/unmatched-refresh.yml
@@ -1,0 +1,25 @@
+##############################################################################
+# Unmatched Items - Metadata Refresh
+#
+# Hidden collection that refreshes metadata for items Plex couldn't match
+# to a metadata source (TMDB/TVDB). Triggers Plex to retry matching.
+##############################################################################
+
+collections:
+  Unmatched Items (Refresh):
+    visible_home: false
+    visible_library: false
+    visible_shared: false
+
+    schedule: daily
+
+    plex_search:
+      all:
+        unmatched: true
+
+    item_refresh: true
+    item_refresh_delay: 2
+    sync_mode: sync
+    collection_order: alpha
+
+    summary: "Internal - refresh metadata for unmatched items to retry agent matching."


### PR DESCRIPTION
## Summary
- Replace 21 stale `bakerboy448/plex-meta-manger` poster URLs with `baker-scripts/pmm-config`
- Add `aired-refresh.yml` — hidden collections for recently-aired metadata refresh
- Add `unmatched-refresh.yml` — hidden collection to retry matching unmatched items
- Update README with new config files

## Test plan
- [ ] Verify poster URLs resolve (GitHub raw content)
- [ ] Verify Kometa loads new configs without errors